### PR TITLE
Don't supply `if_else()` an array

### DIFF
--- a/R/auto_pie_categ.R
+++ b/R/auto_pie_categ.R
@@ -85,13 +85,15 @@ auto_pie_categ <- function(data,
     if (varcat %in% names(data)) {
 
         freq <- table(data[[varcat]])
+        names <- names(freq)
+        dim(freq) <- NULL
         prop <- freq / nrow(data)
         csum <- rev(cumsum(rev(freq)))
         pos <-  freq/2 + lead(csum, 1)
         pos <- if_else(is.na(pos), freq/2, pos)
         namescol <- NULL
 
-        datastats <- data.frame(namescol = names(freq), freq = as.vector(freq), prop = as.vector(prop), csum = as.vector(csum), pos = as.vector(pos))
+        datastats <- data.frame(namescol = names, freq = as.vector(freq), prop = as.vector(prop), csum = as.vector(csum), pos = as.vector(pos))
 
 
       lab_graf_cat <- if (!is.null(table1::label(data[[varcat]]))) table1::label(data[[varcat]]) else varcat


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package supplies `if_else()` an _array_ for the first input. This is no longer allowed, it must be a logical vector without a `dim` attribute.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!